### PR TITLE
Provide 3 different options for detecting current URL

### DIFF
--- a/wallet-integration/guide.mdx
+++ b/wallet-integration/guide.mdx
@@ -82,11 +82,13 @@ browser.webNavigation.onBeforeNavigate.addListener(async function (details) {
 
 ### Option 2: Use the `browser.tabs.onUpdated` API
 
-This approach requires adding the `tabs` permission to your `manifest.json` file:
+This approach requires adding the `tabs` permission to your `manifest.json` file
+and requesting the `"<all_urls>"` host permission:
 
 ```json
 {
-  "permissions": ["tabs"]
+  "permissions": ["tabs"],
+  "host_permissions": ["<all_urls>"]
 }
 ```
 

--- a/wallet-integration/guide.mdx
+++ b/wallet-integration/guide.mdx
@@ -41,15 +41,28 @@ Let's dive deeper into each of these steps:
 The first step is to detect when a user has visited a new website. If you're building a
 web browser extension, you have a couple of choices:
 
-### Use the `browser.onBeforeNavigate` API
+### Option 1: Use the `browser.onBeforeNavigate` API
 
-This approach requires adding the `webNavigation` permission to your `manifest.json` file.
+This approach requires adding the `webNavigation` permission to your `manifest.json` file:
 
 ```json
 {
   "permissions": ["webNavigation"]
 }
 ```
+
+<Warning>
+
+This will trigger a new permissions request when the user installs your
+extension to request access to your browsing history.
+
+Alternatively, you can make this permission optional by adding the
+`"optional_permissions": ["webNavigation"]` key to your `manifest.json` file instead.
+But this will require you to add additional logic to your extension to request this
+permission at the appropriate time (ex. in a settings page, or via a Call to Action
+prompt). You will also need to handle the case where the user denies the permission request.
+
+</Warning>
 
 Then you can listen for the `onBeforeNavigate` event in your Background script:
 
@@ -66,15 +79,30 @@ browser.webNavigation.onBeforeNavigate.addListener(async function (details) {
 });
 ```
 
-### Use the `browser.tabs.onUpdated` API
+### Option 2: Use the `browser.tabs.onUpdated` API
 
-This approach requires adding the `tabs` permission to your `manifest.json` file.
+This approach requires adding the `tabs` permission to your `manifest.json` file
+and providing host permissions for all the domains you want to support:
 
 ```json
 {
-  "permissions": ["tabs"]
+  "permissions": ["tabs"],
+  "host_permissions": ["<all_urls>"]
 }
 ```
+
+<Warning>
+
+If your extension does not already have this permission, this will trigger a new
+permissions request when the user installs your extension to request access to all URLs.
+
+Alternatively, you can make this permission optional by adding the
+`"optional_permissions": ["tabs"]` key to your `manifest.json` file, but this
+will require you to add additional logic to your extension to request this
+permission at the appropriate time (ex. in a settings page, or via a Call to Action
+prompt). You will also need to handle the case where the user denies the permission request.
+
+</Warning>
 
 Then you can listen for the `onUpdated` event in your Background script:
 
@@ -92,7 +120,7 @@ browser.tabs.onUpdated.addListener(async function (tabId, changeInfo, tab) {
 });
 ```
 
-### Get the current URL from a content script
+### Option 3: Get the current URL from a content script
 
 If you're already using a content script in your extension, you can get the current
 URL from the `window.location` object without needing to add any additional permissions.

--- a/wallet-integration/guide.mdx
+++ b/wallet-integration/guide.mdx
@@ -53,14 +53,15 @@ This approach requires adding the `webNavigation` permission to your `manifest.j
 
 <Warning>
 
-This will trigger a new permissions request when the user installs your
-extension to request access to your browsing history.
+If your extension does not already have this permission, this will trigger a new
+permissions request when the user installs your extension to "Read your browsing history".
 
 Alternatively, you can make this permission optional by adding the
 `"optional_permissions": ["webNavigation"]` key to your `manifest.json` file instead.
 But this will require you to add additional logic to your extension to request this
 permission at the appropriate time (ex. in a settings page, or via a Call to Action
-prompt). You will also need to handle the case where the user denies the permission request.
+prompt to opt-in to protection). You will also need to handle the case where the user
+denies the permission request.
 
 </Warning>
 
@@ -81,20 +82,18 @@ browser.webNavigation.onBeforeNavigate.addListener(async function (details) {
 
 ### Option 2: Use the `browser.tabs.onUpdated` API
 
-This approach requires adding the `tabs` permission to your `manifest.json` file
-and providing host permissions for all the domains you want to support:
+This approach requires adding the `tabs` permission to your `manifest.json` file:
 
 ```json
 {
-  "permissions": ["tabs"],
-  "host_permissions": ["<all_urls>"]
+  "permissions": ["tabs"]
 }
 ```
 
 <Warning>
 
 If your extension does not already have this permission, this will trigger a new
-permissions request when the user installs your extension to request access to all URLs.
+permissions request when the user installs your extension to "Read your browsing history".
 
 Alternatively, you can make this permission optional by adding the
 `"optional_permissions": ["tabs"]` key to your `manifest.json` file, but this

--- a/wallet-integration/guide.mdx
+++ b/wallet-integration/guide.mdx
@@ -30,24 +30,79 @@ To achieve this goal, you will need to do the following:
 
 Let's dive deeper into each of these steps:
 
-## Detecting a new website
+## Detecting navigation to a new website
+
+<Note>
+  In the code examples below, we're using Mozilla's
+  [webextension-polyfill](https://github.com/mozilla/webextension-polyfill) to
+  smooth out the differences between the Chrome and Firefox APIs.
+</Note>
 
 The first step is to detect when a user has visited a new website. If you're building a
-web browser extension, you can use the `browser.onBeforeNavigate` API. Here
-we're using Mozilla's [webextension-polyfill](https://github.com/mozilla/webextension-polyfill)
-to smooth out the differences between the Chrome and Firefox APIs.
+web browser extension, you have a couple of choices:
+
+### Use the `browser.onBeforeNavigate` API
+
+This approach requires adding the `webNavigation` permission to your `manifest.json` file.
+
+```json
+{
+  "permissions": ["webNavigation"]
+}
+```
+
+Then you can listen for the `onBeforeNavigate` event in your Background script:
 
 ```ts
 import browser from "webextension-polyfill";
 
 browser.webNavigation.onBeforeNavigate.addListener(async function (details) {
-  //do stuff
+  // Filter out subframes and any navigation events that don't have a URL
+  if (details.frameId !== 0 || !details.url) {
+    return;
+  }
+
+  // ...
 });
 ```
 
-This code would typically go into your `Background` file.
+### Use the `browser.tabs.onUpdated` API
 
-![Background file](https://user-images.githubusercontent.com/10101970/219277025-1a02f736-dbf0-4f63-84f6-611c9a502011.png)
+This approach requires adding the `tabs` permission to your `manifest.json` file.
+
+```json
+{
+  "permissions": ["tabs"]
+}
+```
+
+Then you can listen for the `onUpdated` event in your Background script:
+
+```ts
+import browser from "webextension-polyfill";
+
+browser.tabs.onUpdated.addListener(async function (tabId, changeInfo, tab) {
+  // Filter out any tab change events that aren't complete, aren't for the
+  // active tab, or tabs that don't have a URL
+  if (changeInfo.status !== "complete" || !tab.active || !tab.url) {
+    return;
+  }
+
+  // ...
+});
+```
+
+### Get the current URL from a content script
+
+If you're already using a content script in your extension, you can get the current
+URL from the `window.location` object without needing to add any additional permissions.
+
+```ts
+const url = window.location.href;
+```
+
+You can read this value at any time, but we recommend reading it either when the page
+first loads, or when the user attempts to initiate a transaction in your wallet app.
 
 ## Checking if the website is malicious
 
@@ -73,16 +128,6 @@ export const checkUrl = async (url: string) => {
 
   return data.status === "BLOCKED";
 };
-```
-
-### Extension Permissions Required
-
-To detect when the user visits a new site, you'll need to add the following permissions to your `manifest.json` file:
-
-```json
-{
-  "permissions": ["webNavigation"]
-}
 ```
 
 ## Displaying a warning to the user

--- a/wallet-integration/guide.mdx
+++ b/wallet-integration/guide.mdx
@@ -41,7 +41,7 @@ Let's dive deeper into each of these steps:
 The first step is to detect when a user has visited a new website. If you're building a
 web browser extension, you have a couple of choices:
 
-### Option 1: Use the `browser.onBeforeNavigate` API
+### (Recommended) Option 1: Use the `browser.onBeforeNavigate` API
 
 This approach requires adding the `webNavigation` permission to your `manifest.json` file:
 
@@ -54,14 +54,11 @@ This approach requires adding the `webNavigation` permission to your `manifest.j
 <Warning>
 
 If your extension does not already have this permission, this will trigger a new
-permissions request when the user installs your extension to "Read your browsing history".
+permissions request when the user installs/updates your extension to "Read your browsing history".
 
-Alternatively, you can make this permission optional by adding the
-`"optional_permissions": ["webNavigation"]` key to your `manifest.json` file instead.
-But this will require you to add additional logic to your extension to request this
-permission at the appropriate time (ex. in a settings page, or via a Call to Action
-prompt to opt-in to protection). You will also need to handle the case where the user
-denies the permission request.
+Alternatively, you can make this permission optional and request it at runtime to avoid
+disabling your extension for users who don't want to grant this permission. Read more
+about optional permissions [here](https://developer.chrome.com/docs/extensions/reference/permissions/#overview).
 
 </Warning>
 
@@ -82,26 +79,22 @@ browser.webNavigation.onBeforeNavigate.addListener(async function (details) {
 
 ### Option 2: Use the `browser.tabs.onUpdated` API
 
-This approach requires adding the `tabs` permission to your `manifest.json` file
-and requesting the `"<all_urls>"` host permission:
+This approach requires adding the `tabs` permission to your `manifest.json`:
 
 ```json
 {
-  "permissions": ["tabs"],
-  "host_permissions": ["<all_urls>"]
+  "permissions": ["tabs"]
 }
 ```
 
 <Warning>
 
 If your extension does not already have this permission, this will trigger a new
-permissions request when the user installs your extension to "Read your browsing history".
+permissions request when the user installs/updates your extension to "Read your browsing history".
 
-Alternatively, you can make this permission optional by adding the
-`"optional_permissions": ["tabs"]` key to your `manifest.json` file, but this
-will require you to add additional logic to your extension to request this
-permission at the appropriate time (ex. in a settings page, or via a Call to Action
-prompt). You will also need to handle the case where the user denies the permission request.
+Alternatively, you can make this permission optional and request it at runtime to avoid
+disabling your extension for users who don't want to grant this permission. Read more
+about optional permissions [here](https://developer.chrome.com/docs/extensions/reference/permissions/#overview).
 
 </Warning>
 
@@ -123,6 +116,34 @@ browser.tabs.onUpdated.addListener(async function (tabId, changeInfo, tab) {
 
 ### Option 3: Get the current URL from a content script
 
+This option assumes you already have a content script that runs on every page, ie. you have
+something like this in your `manifest.json`:
+
+```json
+{
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ]
+}
+```
+
+<Warning>
+
+If your extension does not already have this permission, this will trigger a new
+permissions request when the user installs your extension to "Read and change all your
+data on all websites".
+
+This is a very broad permission, and the warning message may scare some users away if
+you don't already have this permission. For this reason, we recommend using one of the
+other options above if possible. But if you need to use this option, you can make this
+permission optional and inject the content script at runtime. Read more about this approach
+[here](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#programmatic).
+
+</Warning>
+
 If you're already using a content script in your extension, you can get the current
 URL from the `window.location` object without needing to add any additional permissions.
 
@@ -132,6 +153,28 @@ const url = window.location.href;
 
 You can read this value at any time, but we recommend reading it either when the page
 first loads, or when the user attempts to initiate a transaction in your wallet app.
+
+You'll need to send this URL to your background script so that it can check if the
+website is malicious. This can be done using message passing:
+
+```ts
+// content.js
+const url = window.location.href;
+
+// send the URL to the background script
+browser.runtime.sendMessage({ type: "CHAINPATROL_CHECK_URL", url });
+```
+
+```ts
+// background.js
+
+// listen for the message from the content script
+browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === "CHAINPATROL_CHECK_URL") {
+    // do something with request.url
+  }
+});
+```
 
 ## Checking if the website is malicious
 


### PR DESCRIPTION
Edits the wallet integration guide to provide 3 options for getting the current URL:

1. `webNavigation` permission + `onBeforeNavigate` event
2. `tabs` permission + `tabs.onUpdated` event (tested in extension in this PR: https://github.com/chainpatrol/chainpatrol-web/pull/347)
3. Read `window.location.href` in content script at either page load time or when initiating a transaction