### PR TITLE
Add Dispute Create API endpoint documentation

### DIFF
--- a/external-api/dispute-create.mdx
+++ b/external-api/dispute-create.mdx
@@ -1,0 +1,125 @@
+---
+title: Dispute Create
+openapi: "POST /dispute/create"
+---
+
+## Overview
+
+The Dispute Create endpoint allows you to create a new dispute for an asset that has been reported or blocked. This is useful when you believe an asset has been incorrectly flagged or if you want to contest a blocking decision.
+
+## Authentication
+
+This endpoint requires an API key. Include your API key in the request headers.
+
+```
+X-API-KEY: your_api_key_here
+```
+
+## Request
+
+<CodeGroup>
+
+```typescript TypeScript
+const response = await fetch(
+  "https://app.chainpatrol.io/api/v2/dispute/create",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-KEY": "YOUR_API_KEY_HERE",
+    },
+    body: JSON.stringify({
+      content: "https://example-phishing-site.com",
+      email: "contact@yourdomain.com", // Optional if the API key is associated with a user that has an email
+      description:
+        "This is not a phishing site, it's our legitimate marketing site.", // Optional
+    }),
+  }
+);
+
+const data = await response.json();
+console.log(data);
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://app.chainpatrol.io/api/v2/dispute/create",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-KEY": "YOUR_API_KEY_HERE",
+    },
+    body: JSON.stringify({
+      content: "https://example-phishing-site.com",
+      email: "contact@yourdomain.com", // Optional if the API key is associated with a user that has an email
+      description:
+        "This is not a phishing site, it's our legitimate marketing site.", // Optional
+    }),
+  }
+);
+
+const data = await response.json();
+console.log(data);
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://app.chainpatrol.io/api/v2/dispute/create",
+    headers={
+        "Content-Type": "application/json",
+        "X-API-KEY": "YOUR_API_KEY_HERE",
+    },
+    json={
+        "content": "https://example-phishing-site.com",
+        "email": "contact@yourdomain.com", # Optional if the API key is associated with a user that has an email
+        "description": "This is not a phishing site, it's our legitimate marketing site." # Optional
+    },
+)
+
+data = response.json()
+print(data)
+```
+
+</CodeGroup>
+
+## Request Parameters
+
+| Parameter     | Type   | Required | Description                                                                                              |
+| ------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------- |
+| `content`     | string | Yes      | The URL or content identifier that you want to dispute                                                   |
+| `email`       | string | No\*     | Contact email for the dispute. _Required if the API key is not associated with a user that has an email_ |
+| `description` | string | No       | Additional details or explanation for the dispute                                                        |
+
+## Response
+
+```json
+{
+  "id": "12345",
+  "content": "https://example-phishing-site.com"
+}
+```
+
+## Response Parameters
+
+| Parameter | Type   | Description                                       |
+| --------- | ------ | ------------------------------------------------- |
+| `id`      | string | The unique identifier for the created dispute     |
+| `content` | string | The content (URL) that was disputed               |
+| `message` | string | Optional message providing additional information |
+
+## Errors
+
+| Status Code | Error Code   | Description                                                                                 |
+| ----------- | ------------ | ------------------------------------------------------------------------------------------- |
+| 400         | BAD_REQUEST  | Invalid input parameters or a dispute already exists for this asset with the provided email |
+| 401         | UNAUTHORIZED | Missing or invalid API key                                                                  |
+| 404         | NOT_FOUND    | The specified asset does not exist                                                          |
+
+## Notes
+
+- A dispute can only be created once per email address for a specific asset
+- If the asset is only blocked in EthPhishingDetect but not in ChainPatrol, a note will automatically be added to the dispute
+- All disputes created via the API will have a system note indicating they were created via the API

--- a/external-api/overview.mdx
+++ b/external-api/overview.mdx
@@ -11,6 +11,14 @@ as a free service to wallets, security apps, and marketplaces.&#x20;
   File a report against a scam.
 </Card>
 
+<Card
+  title="Dispute Create"
+  icon="comment-dots"
+  href="/external-api/dispute-create"
+>
+  Create a dispute for an asset that has been incorrectly flagged.
+</Card>
+
 <Card title="Asset Changelog" icon="book" href="/external-api/asset-changelog">
   Fetch the latest changes to our allowlist/blocklist.
 </Card>

--- a/mint.json
+++ b/mint.json
@@ -118,6 +118,10 @@
       "pages": ["external-api/report-create"]
     },
     {
+      "group": "Disputes",
+      "pages": ["external-api/dispute-create"]
+    },
+    {
       "group": "Metrics",
       "pages": ["external-api/organization-metrics"]
     },


### PR DESCRIPTION
# Added Dispute Create API Documentation

- Introduced a new documentation file for the Dispute Create endpoint, detailing authentication, request parameters, response structure, and error handling.
- Updated mint.json to include the Disputes group with the new Dispute Create page link.
- Added a card for Dispute Create in the external API overview for easy access.

# Description

Added comprehensive documentation for the new Dispute Create API endpoint, which allows users to create disputes for assets that have been incorrectly flagged or blocked. The documentation includes code examples in TypeScript, JavaScript, and Python, along with detailed request/response parameters and error handling information.

Fixes ENG-1234

## Screenshots, Videos (if applicable)

## Additional Notes

The Dispute Create endpoint enables users to contest blocking decisions when they believe an asset has been incorrectly flagged, improving the user experience by providing a formal dispute resolution process.